### PR TITLE
Adding more Group badges/options

### DIFF
--- a/profiles/static/style.css
+++ b/profiles/static/style.css
@@ -94,3 +94,8 @@ a:active {
 	color: #222;
     	text-decoration: none;
 }
+
+.badge-pink {
+  color: #fff;
+  background-color: #cb42a9;
+}

--- a/profiles/templates/include/nav.html
+++ b/profiles/templates/include/nav.html
@@ -29,7 +29,8 @@
                     <a class="dropdown-item" href="/group/active_rtp">Active RTP</a>
                     <a class="dropdown-item" href="/group/rtp">RTP</a>
                     <a class="dropdown-item" href="/group/eboard">Eboard</a>
-                    <a class="dropdown-item" href="/group/3da">3da</a>
+                    <a class="dropdown-item" href="/group/3da">3D Admins</a>
+                    <a class="dropdown-item" href="/group/webmaster">Webmasters</a>
                     <a class="dropdown-item" href="/group/constitutional_maintainers">Constitutional Maintainers</a>
                     <a class="dropdown-item" href="/group/drink">Drink Admins</a>
                 </div>

--- a/profiles/templates/profile.html
+++ b/profiles/templates/profile.html
@@ -61,6 +61,10 @@
 							<span class="badge badge-pill badge-info">Webmaster</span>
 							{% endif %}
 
+							{% if "3da" in member_info.group_list %}
+							<span class="badge badge-pill badge-pink">3D Printer Admin</span>
+							{% endif %}
+
 							{% if "eboard" in member_info.group_list %}
 							<span class="badge badge-pill badge-success">Executive Board</span>
 							{% endif %}


### PR DESCRIPTION
People are proud of their groups. Display more on the profiles of people who have earned them, and show more as options.

This adds 3da's as a badge

And adds 3das, and webmasters to the dropdown list