### PR TITLE
Adding "Former Member" label

### DIFF
--- a/profiles/templates/profile.html
+++ b/profiles/templates/profile.html
@@ -44,6 +44,8 @@
 								Active Member
 								{% elif "honorarymembers" in member_info.group_list %}
 								Honorary Member
+								{% elif "failed" in member_info.group_list %}
+								Former Member
 								{% else %}
 								Alumni Member
 								{% endif %}


### PR DESCRIPTION
To make it more clear when looking at accounts in profiles whether someone is an alumni or if they failed out of our process