### PR TITLE
Removing PR from EBoard Page

### DIFF
--- a/profiles/ldap.py
+++ b/profiles/ldap.py
@@ -101,10 +101,9 @@ def ldap_get_eboard():
             ) + _ldap_get_group_members("eboard-financial") + _ldap_get_group_members("eboard-history"
             ) + _ldap_get_group_members("eboard-imps") + _ldap_get_group_members("eboard-opcomm"
             ) + _ldap_get_group_members("eboard-research") + _ldap_get_group_members("eboard-social"
-            ) + _ldap_get_group_members("eboard-secretary") + _ldap_get_group_members("eboard-pr")
+            ) + _ldap_get_group_members("eboard-secretary")
 
     return members
-
 
 # Status checkers
 


### PR DESCRIPTION
We don't have the position, or the ldap group anymore, time to delet