### PR TITLE
404 handling and template fixes

### DIFF
--- a/profiles/__init__.py
+++ b/profiles/__init__.py
@@ -187,6 +187,7 @@ def clear_cache(info=None):
     return redirect(request.referrer, 302)
 
 
+@app.errorhandler(404)
 @app.errorhandler(500)
 def handle_internal_error(e):
     if isinstance(e.original_exception, BadQueryError):

--- a/profiles/templates/404.html
+++ b/profiles/templates/404.html
@@ -44,7 +44,7 @@
     <div>
     <h1 class="center">Error 404</h1>
     <h2 class="center">Page does not exist!</h2>
-    <img class="center" src="{{ url_for('static', filename='/assets/images/tvstatic.gif') }}">
+    <img class="center" src="{{ url_for('static', filename='assets/images/tvstatic.gif') }}">
     <h2 id="message" class="center">Message: "{{ message }}"</h2>
     </div>
 </body>


### PR DESCRIPTION
Two fixes:
* Adding the 404 handling decorator to the 404 handling function (wasn't done previously for some reason)
* Fixing the 404 page's link to the floating tv gif
