### PR TITLE
Name Quickfix

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,10 +18,10 @@ jobs:
     - name: Install ldap dependencies
       run: sudo apt-get install libldap2-dev libsasl2-dev
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/profiles/ldap.py
+++ b/profiles/ldap.py
@@ -259,12 +259,13 @@ def ldap_update_profile(form_input, uid):
         if len(full_name.split()) <=1:
             account.sn = full_name
         else:
-            account.sn = full_name.removeprefix(account.givenname).strip() # thanks mom
-        initial_string = ""
-        for i in full_name.split():
-            initial_string += i[0].upper()
-        account.initials = initial_string
+            account.sn = "".join(full_name.split().pop(0))
+            # account.sn = full_name.removeprefix(account.givenname).strip() # thanks mom
+            # use above when upgraded to python 3.9
         account.displayname = full_name + " (" + uid + ")"
+
+    if not form_input["initials"] == account.initials:
+        account.initials = form_input["initials"]
 
     if not form_input["birthday"] == account.birthday:
         date = form_input["birthday"].split('/')

--- a/profiles/ldap.py
+++ b/profiles/ldap.py
@@ -259,7 +259,7 @@ def ldap_update_profile(form_input, uid):
         if len(full_name.split()) <=1:
             account.sn = full_name
         else:
-            account.sn = "".join(full_name.split().pop(0))
+            account.sn = full_name.removeprefix(account.givenname).strip() # thanks mom
         initial_string = ""
         for i in full_name.split():
             initial_string += i[0].upper()

--- a/profiles/ldap.py
+++ b/profiles/ldap.py
@@ -259,9 +259,8 @@ def ldap_update_profile(form_input, uid):
         if len(full_name.split()) <=1:
             account.sn = full_name
         else:
-            account.sn = "".join(full_name.split().pop(0))
-            # account.sn = full_name.removeprefix(account.givenname).strip() # thanks mom
-            # use above when upgraded to python 3.9
+            account.sn = full_name.removeprefix(account.givenname).strip() 
+
         account.displayname = full_name + " (" + uid + ")"
 
     if not form_input["initials"] == account.initials:
@@ -415,9 +414,9 @@ def get_image(uid):
     # Get Gravatar
     url = get_gravatar(uid)
     try:
-        gravatar = urllib.request.urlopen(url)
-        if gravatar.getcode() == 200:
-            return redirect(url, code=302)
+        with urllib.request.urlopen(url) as gravatar:
+            if gravatar.getcode() == 200:
+                return redirect(url, code=302)
     except urllib.error.HTTPError:
         pass
 

--- a/profiles/ldap.py
+++ b/profiles/ldap.py
@@ -252,7 +252,19 @@ def ldap_update_profile(form_input, uid):
             form_input[key] = None
 
     if not form_input["name"] == account.cn:
-        account.cn = form_input["name"]
+        full_name = form_input["name"]
+        account.cn = full_name
+        account.gecos = full_name
+        account.givenname = full_name.split()[0]
+        if len(full_name.split()) <=1:
+            account.sn = full_name
+        else:
+            account.sn = "".join(full_name.split().pop(0))
+        initial_string = ""
+        for i in full_name.split():
+            initial_string += i[0].upper()
+        account.initials = initial_string
+        account.displayname = full_name + " (" + uid + ")"
 
     if not form_input["birthday"] == account.birthday:
         date = form_input["birthday"].split('/')

--- a/profiles/static/js/edit.js
+++ b/profiles/static/js/edit.js
@@ -21,6 +21,7 @@ $(function() {
 
 		var form_data = { 
 			"name": $("#user-name").val(),
+			"initials": $("#user-initials").val(),
 			"birthday": $("#user-birthday").val(),
 			"phone": $(".user-mobile").map(function() {
 				return $(this).val();

--- a/profiles/templates/profile.html
+++ b/profiles/templates/profile.html
@@ -236,6 +236,14 @@
 
 							<div class="col-6 mb-4">
 								<h6 class="card-subtitle text-muted mb-2">
+									<i class="fas fa-comments"></i> Initials
+								</h6>
+								<p class="card-text user-form-value mb-0">{{ member_info.user_obj.initials }}</p>
+								<input type="text" class="form-control form-control-sm user-form-input user-initials" id="user-initials" value="{{ member_info.user_obj.initials }}">
+							</div>
+
+							<div class="col-6 mb-4">
+								<h6 class="card-subtitle text-muted mb-2">
 									<i class="fas fa-lock"></i> Last Login
 								</h6>
 								<p class="card-text">{{ member_info.lastlogin }}</p>

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -51,6 +51,7 @@ def get_member_info(uid):
         "uid": account.uid,
         "ritUid": account.ritDn,
         "name": account.cn,
+        "initials": account.initials,
         "active": ldap_is_active(account),
         "onfloor": ldap_is_onfloor(account),
         "room": ldap_get_roomnumber(account),


### PR DESCRIPTION
This is for issue #74, updates the ldap_update_profile method to update all ldap entries relating to name rather than just the `cn` field (including `gecos`,`givenname`,`sn`, `initials`, and `displayname`.)

Resolves #74