### PR TITLE
Fix clearing profile URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,5 +88,5 @@ Reach out to an RTP to get OIDC credentials that will allow you to develop local
 Code Standards
 ------------
 
-Use Pylint to ensure your code follows standards. Commits will be pylinted by Travis CI, if your
+Use Pylint to ensure your code follows standards. Commits will be pylinted by GitHub Actions, if your
 build fails you must fix whatever it tells you is wrong before it will be merged.

--- a/profiles/__init__.py
+++ b/profiles/__init__.py
@@ -24,6 +24,7 @@ auth = OIDCAuthentication(app, issuer=app.config["OIDC_ISSUER"],
                           client_registration_info=app.config["OIDC_CLIENT_CONFIG"])
 
 # Sentry
+# pylint: disable=abstract-class-instantiated
 sentry_sdk.init(
     dsn=app.config['SENTRY_DSN'],
     integrations=[FlaskIntegration(), SqlalchemyIntegration()]
@@ -82,7 +83,7 @@ def user(uid=None, info=None):
 @before_request
 def results():
     searched = request.form['query']
-    return redirect("/search/{}".format(searched), 302)
+    return redirect(f"/search/{searched}", 302)
 
 
 @app.route("/search", methods=["GET"])

--- a/profiles/ldap.py
+++ b/profiles/ldap.py
@@ -280,7 +280,9 @@ def ldap_update_profile(form_input, uid):
             account.ritYear = form_input["ritYear"]
 
     if not form_input["website"] == account.homepageURL:
-        if re.search(r"^https?:\/\/.+", form_input["website"]):
+        if form_input["website"] is None or form_input["website"].strip() == "":
+            account.homepageURL = None
+        elif re.search(r"^https?:\/\/.+", form_input["website"]):
             account.homepageURL = form_input["website"]
         else:
             account.homepageURL = "http://" + form_input["website"]
@@ -289,12 +291,16 @@ def ldap_update_profile(form_input, uid):
         account.twitterName = form_input["twitter"]
 
     if not form_input["blog"] == account.blogURL:
-        if re.search(r"^https?:\/\/.+", form_input["blog"]):
+        if form_input["blog"] is None or form_input["blog"].strip() == "":
+            account.blogURL = None
+        elif re.search(r"^https?:\/\/.+", form_input["blog"]):
             account.blogURL = form_input["blog"]
         else:
             account.blogURL = "http://" + form_input["blog"]
 
     if not form_input["resume"] == account.resumeURL:
+        if form_input["resume"] is None or form_input["resume"].strip() == "":
+            account.resumeURL = None
         if re.search(r"^https?:\/\/.+", form_input["resume"]):
             account.resumeURL = form_input["resume"]
         else:

--- a/profiles/ldap.py
+++ b/profiles/ldap.py
@@ -102,7 +102,7 @@ def ldap_get_group_desc(group):
         results = con.search_s(
             "cn=groups,cn=accounts,dc=csh,dc=rit,dc=edu",
             ldap.SCOPE_SUBTREE,
-            "(cn=%s)" % group,
+            f"(cn={group})",
             ['description'])
         return results[0][1]['description'][0].decode('utf-8')
     except IndexError as inderr:
@@ -216,9 +216,7 @@ def ldap_set_non_current_student(account):
 
 
 def ldap_multi_update(uid, attribute, value):
-    dn = "uid={},cn=users,cn=accounts,dc=csh,dc=rit,dc=edu".format(
-        uid
-    )
+    dn = f"uid={uid},cn=users,cn=accounts,dc=csh,dc=rit,dc=edu"
 
     try:
         current = _ldap.get_member(uid, uid=True).get(attribute)
@@ -408,9 +406,9 @@ def get_image(uid):
     # Get Gravatar
     url = get_gravatar(uid)
     try:
-        gravatar = urllib.request.urlopen(url)
-        if gravatar.getcode() == 200:
-            return redirect(url, code=302)
+        with urllib.request.urlopen(url) as gravatar:
+            if gravatar.getcode() == 200:
+                return redirect(url, code=302)
     except urllib.error.HTTPError:
         pass
 


### PR DESCRIPTION
When attempting to clear a URL in a user's profile, a 500 error is returned. This is because the new value is `None`, which causes the regex matching for url prefixes to error. This pull request adds a check for if the new value is None.

This also includes fixes for pylint warnings