### PR TITLE
Fixing flask startup failure

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -13,5 +13,6 @@ git+https://github.com/maxcountryman/flask-uploads@master
 pylint~=2.13.9
 Pillow==8.4.0
 requests~=2.27.1
-sentry-sdk[flask]~=0.19.5
+sentry-sdk[flask]~=1.5.12
+markupsafe==2.0.1
 Werkzeug==0.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,8 +83,9 @@ mako==1.2.0
     # via
     #   alembic
     #   oic
-markupsafe==2.1.1
+markupsafe==2.0.1
     # via
+    #   -r requirements.in
     #   jinja2
     #   mako
 mccabe==0.7.0
@@ -136,7 +137,7 @@ requests==2.27.1
     #   -r requirements.in
     #   oic
     #   pyjwkest
-sentry-sdk[flask]==0.19.5
+sentry-sdk[flask]==1.5.12
     # via -r requirements.in
 six==1.16.0
     # via


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/sentry_sdk/integrations/flask.py", line 32, in <module>
    from flask import (  # type: ignore
  File "/usr/local/lib/python3.9/site-packages/ddtrace/vendor/wrapt/importer.py", line 156, in load_module
    module = self.loader.load_module(fullname)
  File "/usr/local/lib/python3.9/site-packages/flask/__init__.py", line 14, in <module>
    from jinja2 import escape
  File "/usr/local/lib/python3.9/site-packages/jinja2/__init__.py", line 12, in <module>
    from .environment import Environment
  File "/usr/local/lib/python3.9/site-packages/jinja2/environment.py", line 25, in <module>
    from .defaults import BLOCK_END_STRING
  File "/usr/local/lib/python3.9/site-packages/jinja2/defaults.py", line 3, in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
  File "/usr/local/lib/python3.9/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/usr/local/lib/python3.9/site-packages/markupsafe/__init__.py)
```

This error occurred in a few repos with flask 1.1.4, fix is to pin markupsafe to `2.0.1` and update sentry to one that recognizes flask 1.1.4