### PR TITLE
Switched order of PR and Secretary on eboard group page

### DIFF
--- a/profiles/ldap.py
+++ b/profiles/ldap.py
@@ -116,7 +116,7 @@ def ldap_get_eboard():
             ) + _ldap_get_group_members("eboard-financial") + _ldap_get_group_members("eboard-history"
             ) + _ldap_get_group_members("eboard-imps") + _ldap_get_group_members("eboard-opcomm"
             ) + _ldap_get_group_members("eboard-research") + _ldap_get_group_members("eboard-social"
-            ) + _ldap_get_group_members("eboard-secretary") + _ldap_get_group_members("eboard-pr")
+            ) + _ldap_get_group_members("eboard-pr") + _ldap_get_group_members("eboard-secretary")
 
     return members
 


### PR DESCRIPTION
PR now displays before secretary instead of after