### PR TITLE
Made the Segfault tag Comic Sans

### DIFF
--- a/profiles/static/style.css
+++ b/profiles/static/style.css
@@ -96,7 +96,7 @@ a:active {
 .badge-strange {
 	color: #000;
 	background-color: #ffffff; 
-	font-family: "Comic Sans"; 
+	font-family: "Comic Sans MS", "Comic Sans", cursive; 
 }
 
 .profile-link,


### PR DESCRIPTION
Changed the font of the Segfault profiles tag to Comic Sans (probably). I should've done this forever ago. 