### PR TITLE
Handle stray BadQueryErrors (#249)

### DIFF
--- a/profiles/__init__.py
+++ b/profiles/__init__.py
@@ -89,7 +89,13 @@ def home(info=None):
 @auth.oidc_auth("default")
 @before_request
 def user(uid=None, info=None):
-    return render_template("profile.html", info=info, member_info=get_member_info(uid))
+    try:
+        return render_template("profile.html", info=info, member_info=get_member_info(uid))
+    except BadQueryError as bqe:
+        # ldap_get_member() returns a BadQueryError if getting the user's information fails.
+        # Flask already treats a stray BadQueryError as a 404, but actually handling it prevents the traceback
+        # from getting dumped into the log.
+        return render_template("404.html", message=bqe), 404
 
 
 @app.route("/results", methods=["POST"])
@@ -172,7 +178,10 @@ def logout():
 
 @app.route("/image/<uid>", methods=["GET"])
 def image(uid):
-    return get_image(uid)
+    try:
+        return get_image(uid)
+    except BadQueryError as bqe:
+        return render_template("404.html", message=bqe), 404
 
 
 @app.route("/clearcache")


### PR DESCRIPTION
`ldap_get_member()` returns a `BadQueryError` whenever getting a user's information fails, and currently this goes uncaught in the `/user/<uid>` and `/image/<uid>`. Flask already handles an uncaught `BadQueryError` by presenting a 404 page, but the exception is still throw out into the console.

This PR just makes it so those endpoints will catch a `BadQueryError` and return the 404 page directly, rather than letting it go uncaught and having it fall back onto Flask to handle it. (Fix for #249)