### PR TITLE
change from old Twitter name to new X name

### DIFF
--- a/profiles/templates/profile.html
+++ b/profiles/templates/profile.html
@@ -171,7 +171,7 @@
 									<input type="text" class="form-control form-control-sm" id="user-google" value="{{ member_info.user_obj.googleScreenName }}" placeholder="Google Account">
 								</div>
 								<div class="form-group user-form-input">
-									<label for="user-twitter">Twitter Username</label>
+									<label for="user-twitter">X Username</label>
 									<input type="text" class="form-control form-control-sm" id="user-twitter" value="{{ member_info.user_obj.twitterName }}" placeholder="Twitter Username">
 								</div>
 							</div>


### PR DESCRIPTION
## What

In the edit form, it still had the old name for X: Twitter. I fixed it to actually refer to the proper name.

## Why

Here at CSH, we should strive for accuracy and this is a glaring inaccruacy in one of our core services.

## Test Plan

This is a simple change to the HTML template.

## Env Vars

no change

## Documentation

No docs need changing

## Checklist

- [x] Tested all changes locally
--  No testing, should be good
