### PR TITLE
fix: people getting logged in as each other

### DIFF
--- a/profiles/__init__.py
+++ b/profiles/__init__.py
@@ -78,6 +78,14 @@ from profiles.utils import before_request, get_member_info, process_image
 # pylint: enable=wrong-import-position
 
 
+@app.after_request
+def set_cache_headers(response):
+    if "Cache-Control" not in response.headers:
+        response.headers["Cache-Control"] = "no-store"
+        response.headers["Vary"] = "Cookie"
+    return response
+
+
 @app.route("/", methods=["GET"])
 @auth.oidc_auth("default")
 @before_request


### PR DESCRIPTION
## What

- Adds cache control headers so that proxies don't cache being logged in as somebody else :P
- No guarantee this actually works :PP

## Why

- People be getting logged in as each other

## Test Plan

- Ship it

## Env Vars

N/A

## Documentation

N/A

## Checklist

- [x] Tested all changes locally

(not really sure how to test these locally, but the app doesn't explode?)